### PR TITLE
PEP8 fixes

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -187,22 +187,22 @@ htmlhelp_basename = 'libevdevPythonwrapperdoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'libevdevPythonwrapper.tex', u'libevdev Python wrapper Documentation',
-   u'Peter Hutterer', 'manual'),
+    ('index', 'libevdevPythonwrapper.tex', u'libevdev Python wrapper Documentation',
+     u'Peter Hutterer', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -245,9 +245,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'libevdevPythonwrapper', u'libevdev Python wrapper Documentation',
-   u'Peter Hutterer', 'libevdevPythonwrapper', 'One line description of project.',
-   'Miscellaneous'),
+    ('index', 'libevdevPythonwrapper', u'libevdev Python wrapper Documentation',
+     u'Peter Hutterer', 'libevdevPythonwrapper', 'One line description of project.',
+     'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.
@@ -265,4 +265,3 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
-

--- a/examples/evtest.py
+++ b/examples/evtest.py
@@ -79,6 +79,7 @@ def main(args):
 
         print_events(l)
 
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: {} /dev/input/eventX".format(sys.argv[0]))

--- a/examples/evtest.py
+++ b/examples/evtest.py
@@ -5,16 +5,17 @@ from __future__ import print_function
 import sys
 import libevdev
 
+
 def print_capabilities(l):
     v = l.driver_version
     print("Input driver version is {}.{}.{}".format(v >> 16, (v >> 8) & 0xff, v & 0xff))
     id = l.id
-    print("Input device ID: bus {:#x} vendor {:#x} product {:#x} version {:#x}".format(\
-            id["bustype"],
-            id["vendor"],
-            id["product"],
-            id["version"],
-            ))
+    print("Input device ID: bus {:#x} vendor {:#x} product {:#x} version {:#x}".format(
+        id["bustype"],
+        id["vendor"],
+        id["product"],
+        id["version"],
+    ))
     print("Input device name: {}".format(l.name))
     print("Supported events:")
 
@@ -47,9 +48,10 @@ def print_capabilities(l):
                     print("       {:10s} {:6d}".format(k, v))
 
     print("Properties:")
-    for p in range(0x1f): # PROP_MAX
+    for p in range(0x1f):  # PROP_MAX
         if l.has_property(p):
             print("  Property type {} ({})".format(p, libevdev.Libevdev.property_to_name(p)))
+
 
 def print_events(l):
     while True:
@@ -65,14 +67,15 @@ def print_events(l):
         else:
             print("type {} ({}) code {} ({}), value {}".format(e.type, e.type_name, e.code, e.code_name, e.value))
 
+
 def main(args):
     path = args[1]
     with open(path, "rb") as fd:
         l = libevdev.Libevdev(fd)
         print_capabilities(l)
-        print ("################################\n"
-               "#      Waiting for events      #\n"
-               "################################")
+        print("################################\n"
+              "#      Waiting for events      #\n"
+              "################################")
 
         print_events(l)
 

--- a/examples/uinput.py
+++ b/examples/uinput.py
@@ -17,5 +17,6 @@ def main(args):
     except OSError as e:
         print(e)
 
+
 if __name__ == "__main__":
     main(sys.argv)

--- a/examples/uinput.py
+++ b/examples/uinput.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import sys
 import libevdev
 
+
 def main(args):
     dev = libevdev.Libevdev()
     dev.name = "test device"

--- a/libevdev/__init__.py
+++ b/libevdev/__init__.py
@@ -20,30 +20,36 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import os
-import ctypes
-import errno
-from ctypes import c_char_p, c_int, c_uint, c_void_p, c_long, c_int32, c_uint16
+import os as _os
+import ctypes as _ctypes
+import errno as _errno
+from ctypes import c_char_p as _c_char_p
+from ctypes import c_int as _c_int
+from ctypes import c_uint as _c_uint
+from ctypes import c_void_p as _c_void_p
+from ctypes import c_long as _c_long
+from ctypes import c_int32 as _c_int32
+from ctypes import c_uint16 as _c_uint16
 
 READ_FLAG_SYNC = 0x1
 READ_FLAG_NORMAL = 0x2
 READ_FLAG_FORCE_SYNC = 0x4
 READ_FLAG_BLOCKING = 0x8
 
-class _InputAbsinfo(ctypes.Structure):
-    _fields_ = [("value", c_int32),
-                ("minimum", c_int32),
-                ("maximum", c_int32),
-                ("fuzz", c_int32),
-                ("flat", c_int32),
-                ("resolution", c_int32)]
+class _InputAbsinfo(_ctypes.Structure):
+    _fields_ = [("value", _c_int32),
+                ("minimum", _c_int32),
+                ("maximum", _c_int32),
+                ("fuzz", _c_int32),
+                ("flat", _c_int32),
+                ("resolution", _c_int32)]
 
-class _InputEvent(ctypes.Structure):
-    _fields_ = [("sec", c_long),
-                ("usec", c_long),
-                ("type", c_uint16),
-                ("code", c_uint16),
-                ("value", c_int32)]
+class _InputEvent(_ctypes.Structure):
+    _fields_ = [("sec", _c_long),
+                ("usec", _c_long),
+                ("type", _c_uint16),
+                ("code", _c_uint16),
+                ("value", _c_int32)]
 
 class _LibraryWrapper(object):
     """
@@ -104,52 +110,52 @@ class Libevdev(_LibraryWrapper):
 
     @staticmethod
     def _cdll():
-        return ctypes.CDLL("libevdev.so.2", use_errno=True)
+        return _ctypes.CDLL("libevdev.so.2", use_errno=True)
 
     _api_prototypes = {
         #const char *libevdev_event_type_get_name(unsigned int type);
         "libevdev_event_type_get_name": {
-            "argtypes": (c_uint,),
-            "restype": c_char_p
+            "argtypes": (_c_uint,),
+            "restype": _c_char_p
             },
         #int libevdev_event_type_from_name(const char *name);
         "libevdev_event_type_from_name": {
-            "argtypes": (c_char_p,),
-            "restype": c_int
+            "argtypes": (_c_char_p,),
+            "restype": _c_int
             },
         #const char *libevdev_event_code_get_name(unsigned int type, unsigned int code);
         "libevdev_event_code_get_name": {
-            "argtypes": (c_uint, c_uint,),
-            "restype": c_char_p
+            "argtypes": (_c_uint, _c_uint,),
+            "restype": _c_char_p
             },
         #int libevdev_event_code_from_name(unsigned int type, const char *name);
         "libevdev_event_code_from_name": {
-            "argtypes": (c_uint, c_char_p,),
-            "restype": c_int
+            "argtypes": (_c_uint, _c_char_p,),
+            "restype": _c_int
             },
         #const char *libevdev_property_get_name(unsigned int prop);
         "libevdev_property_get_name": {
-            "argtypes": (c_uint,),
-            "restype": c_char_p,
+            "argtypes": (_c_uint,),
+            "restype": _c_char_p,
             },
         #int libevdev_property_from_name(const char *name);
         "libevdev_property_from_name": {
-            "argtypes": (c_char_p,),
-            "restype": c_int
+            "argtypes": (_c_char_p,),
+            "restype": _c_int
             },
         #void libevdev_event_type_get_max(int)
         "libevdev_event_type_get_max": {
-            "argtypes": (c_int, ),
-            "restype": c_int,
+            "argtypes": (_c_int, ),
+            "restype": _c_int,
             },
         #struct libevdev *libevdev_new(void);
         "libevdev_new": {
             "argtypes": (),
-            "restype": c_void_p,
+            "restype": _c_void_p,
             },
         #struct libevdev *libevdev_free(struct libevdev *);
         "libevdev_free": {
-            "argtypes": (c_void_p,),
+            "argtypes": (_c_void_p,),
             "restype": None,
             },
         ###############################
@@ -157,185 +163,185 @@ class Libevdev(_LibraryWrapper):
         ###############################
         #const char * libevdev_get_name(struct libevdev *);
         "libevdev_get_name": {
-            "argtypes": (c_void_p,),
-            "restype": c_char_p,
+            "argtypes": (_c_void_p,),
+            "restype": _c_char_p,
             },
         #void libevdev_set_name(struct libevdev *, const char*);
         "libevdev_set_name": {
-            "argtypes": (c_void_p, c_char_p),
+            "argtypes": (_c_void_p, _c_char_p),
             "restype": None,
             },
         #const char * libevdev_get_phys(struct libevdev *);
         "libevdev_get_phys": {
-            "argtypes": (c_void_p,),
-            "restype": c_char_p,
+            "argtypes": (_c_void_p,),
+            "restype": _c_char_p,
             },
         #void libevdev_set_phys(struct libevdev *, const char*);
         "libevdev_set_phys": {
-            "argtypes": (c_void_p, c_char_p),
+            "argtypes": (_c_void_p, _c_char_p),
             "restype": None,
             },
         #const char * libevdev_get_uniq(struct libevdev *);
         "libevdev_get_uniq": {
-            "argtypes": (c_void_p,),
-            "restype": c_char_p,
+            "argtypes": (_c_void_p,),
+            "restype": _c_char_p,
             },
         #void libevdev_set_uniq(struct libevdev *, const char*);
         "libevdev_set_uniq": {
-            "argtypes": (c_void_p, c_char_p),
+            "argtypes": (_c_void_p, _c_char_p),
             "restype": None,
             },
         #int libevdev_get_driver_version(struct libevdev *);
         "libevdev_get_driver_version": {
-            "argtypes": (c_void_p, ),
-            "restype": c_int,
+            "argtypes": (_c_void_p, ),
+            "restype": _c_int,
             },
         #void libevdev_set_clock_id(struct libevdev *, int)
         "libevdev_set_clock_id": {
-            "argtypes": (c_void_p, c_int),
-            "restype": c_int,
+            "argtypes": (_c_void_p, _c_int),
+            "restype": _c_int,
             },
         ###############################
         # Custom getters and setters  #
         ###############################
         #int libevdev_get_id_bustype(struct libevdev *)
         "libevdev_get_id_bustype": {
-            "argtypes": (c_void_p,),
-            "restype": c_int,
+            "argtypes": (_c_void_p,),
+            "restype": _c_int,
             },
         #int libevdev_get_id_vendor(struct libevdev *)
         "libevdev_get_id_vendor": {
-            "argtypes": (c_void_p,),
-            "restype": c_int,
+            "argtypes": (_c_void_p,),
+            "restype": _c_int,
             },
         #int libevdev_get_id_product(struct libevdev *)
         "libevdev_get_id_product": {
-            "argtypes": (c_void_p,),
-            "restype": c_int,
+            "argtypes": (_c_void_p,),
+            "restype": _c_int,
             },
         #int libevdev_get_id_version(struct libevdev *)
         "libevdev_get_id_version": {
-            "argtypes": (c_void_p,),
-            "restype": c_int,
+            "argtypes": (_c_void_p,),
+            "restype": _c_int,
             },
         #void libevdev_set_id_bustype(struct libevdev *, int)
         "libevdev_set_id_bustype": {
-            "argtypes": (c_void_p, c_int),
+            "argtypes": (_c_void_p, _c_int),
             "restype": None,
             },
         #void libevdev_set_id_vendor(struct libevdev *, int)
         "libevdev_set_id_vendor": {
-            "argtypes": (c_void_p, c_int),
+            "argtypes": (_c_void_p, _c_int),
             "restype": None,
             },
         #void libevdev_set_id_product(struct libevdev *, int)
         "libevdev_set_id_product": {
-            "argtypes": (c_void_p, c_int),
+            "argtypes": (_c_void_p, _c_int),
             "restype": None,
             },
         #void libevdev_set_id_version(struct libevdev *, int)
         "libevdev_set_id_version": {
-            "argtypes": (c_void_p, c_int),
+            "argtypes": (_c_void_p, _c_int),
             "restype": None,
             },
         # int libevdev_set_fd(struct libevdev *, int)
         "libevdev_set_fd" : {
-            "argtypes" : (c_void_p, c_int),
-            "restype" : c_int,
+            "argtypes" : (_c_void_p, _c_int),
+            "restype" : _c_int,
         },
         # int libevdev_change_fd(struct libevdev *, int)
         "libevdev_change_fd" : {
-            "argtypes" : (c_void_p, c_int),
-            "restype" : c_int,
+            "argtypes" : (_c_void_p, _c_int),
+            "restype" : _c_int,
         },
         # int libevdev_get_fd(struct libevdev *)
         "libevdev_get_fd" : {
-            "argtypes" : (c_void_p, ),
-            "restype" : c_int,
+            "argtypes" : (_c_void_p, ),
+            "restype" : _c_int,
         },
         # int libevdev_grab(struct libevdev *)
         "libevdev_grab": {
-            "argtypes" : (c_void_p, c_int),
-            "restype" : c_int,
+            "argtypes" : (_c_void_p, _c_int),
+            "restype" : _c_int,
         },
         # const struct input_absinfo *libevdev_get_abs_info(struct libevdev*,  int code)
         "libevdev_get_abs_info" : {
-            "argtypes" : (c_void_p, c_int),
-            "restype" : ctypes.POINTER(_InputAbsinfo),
+            "argtypes" : (_c_void_p, _c_int),
+            "restype" : _ctypes.POINTER(_InputAbsinfo),
         },
         # We don't need to wrap libevdev_set_abs_info(), we get the same
         # using get_abs_info and overwrite the values.
         #
         # const struct input_absinfo *libevdev_get_abs_info(struct libevdev*,  int code)
         "libevdev_kernel_set_abs_info" : {
-            "argtypes" : (c_void_p, ctypes.POINTER(_InputAbsinfo)),
-            "restype" : (c_int)
+            "argtypes" : (_c_void_p, _ctypes.POINTER(_InputAbsinfo)),
+            "restype" : (_c_int)
         },
         ##########################
         # Various has_ functions #
         ##########################
         "libevdev_has_property" : {
-            "argtypes" : (c_void_p, c_int),
-            "restype" : (c_int)
+            "argtypes" : (_c_void_p, _c_int),
+            "restype" : (_c_int)
         },
         "libevdev_has_event_type" : {
-            "argtypes" : (c_void_p, c_int),
-            "restype" : (c_int)
+            "argtypes" : (_c_void_p, _c_int),
+            "restype" : (_c_int)
         },
         "libevdev_has_event_code" : {
-            "argtypes" : (c_void_p, c_int, c_int),
-            "restype" : (c_int)
+            "argtypes" : (_c_void_p, _c_int, _c_int),
+            "restype" : (_c_int)
         },
         ##########################
         # Other functions        #
         ##########################
         "libevdev_set_event_value" : {
-            "argtypes" : (c_void_p, c_int, c_int, c_int),
-            "restype" : (c_int)
+            "argtypes" : (_c_void_p, _c_int, _c_int, _c_int),
+            "restype" : (_c_int)
         },
         "libevdev_get_event_value" : {
-            "argtypes" : (c_void_p, c_int, c_int),
-            "restype" : (c_int),
+            "argtypes" : (_c_void_p, _c_int, _c_int),
+            "restype" : (_c_int),
         },
         "libevdev_enable_event_type" : {
-            "argtypes" : (c_void_p, c_int),
-            "restype" : (c_int),
+            "argtypes" : (_c_void_p, _c_int),
+            "restype" : (_c_int),
         },
         "libevdev_enable_event_code" : {
-            "argtypes" : (c_void_p, c_int, c_int, c_void_p),
-            "restype" : (c_int),
+            "argtypes" : (_c_void_p, _c_int, _c_int, _c_void_p),
+            "restype" : (_c_int),
         },
         "libevdev_disable_event_type" : {
-            "argtypes" : (c_void_p, c_int),
-            "restype" : (c_int),
+            "argtypes" : (_c_void_p, _c_int),
+            "restype" : (_c_int),
         },
         "libevdev_disable_event_code" : {
-            "argtypes" : (c_void_p, c_int, c_int),
-            "restype" : (c_int),
+            "argtypes" : (_c_void_p, _c_int, _c_int),
+            "restype" : (_c_int),
         },
         "libevdev_next_event" : {
-            "argtypes" : (c_void_p, c_uint, ctypes.POINTER(_InputEvent)),
-            "restype" : c_int,
+            "argtypes" : (_c_void_p, _c_uint, _ctypes.POINTER(_InputEvent)),
+            "restype" : _c_int,
         },
         "libevdev_get_num_slots" : {
-            "argtypes" : (c_void_p,),
-            "restype" : c_int,
+            "argtypes" : (_c_void_p,),
+            "restype" : _c_int,
         },
         "libevdev_get_current_slot" : {
-            "argtypes" : (c_void_p,),
-            "restype" : c_int,
+            "argtypes" : (_c_void_p,),
+            "restype" : _c_int,
         },
         "libevdev_get_slot_value" : {
-            "argtypes" : (c_void_p, c_uint, c_uint),
-            "restype" : c_int,
+            "argtypes" : (_c_void_p, _c_uint, _c_uint),
+            "restype" : _c_int,
         },
         "libevdev_set_slot_value" : {
-            "argtypes" : (c_void_p, c_uint, c_uint, c_int),
-            "restype" : c_int,
+            "argtypes" : (_c_void_p, _c_uint, _c_uint, _c_int),
+            "restype" : _c_int,
         },
         "libevdev_has_event_pending" : {
-            "argtypes" : (c_void_p,),
-            "restype" : c_int,
+            "argtypes" : (_c_void_p,),
+            "restype" : _c_int,
         },
         }
 
@@ -503,7 +509,7 @@ class Libevdev(_LibraryWrapper):
             r = self._change_fd(self._ctx, fd)
 
         if r != 0:
-            raise OSError(-r, os.strerror(-r))
+            raise OSError(-r, _os.strerror(-r))
 
         # sanity check:
         if self._get_fd(self._ctx) != fd:
@@ -776,9 +782,9 @@ class Libevdev(_LibraryWrapper):
                                      data.get("fuzz", 0),
                                      data.get("flat", 0), \
                                      data.get("resolution", 0))
-                data = ctypes.pointer(data)
+                data = _ctypes.pointer(data)
             elif t == 0x14: #EV_REP
-                data = ctypes.pointer(data)
+                data = _ctypes.pointer(data)
             self._enable_event_code(self._ctx, t, c, data)
 
     def disable(self, event_type, event_code=None):
@@ -823,8 +829,8 @@ class Libevdev(_LibraryWrapper):
 
         """
         ev = _InputEvent()
-        rc = self._next_event(self._ctx, flags, ctypes.byref(ev))
-        if rc < -errno.EAGAIN:
+        rc = self._next_event(self._ctx, flags, _ctypes.byref(ev))
+        if rc < -_errno.EAGAIN:
             return None
 
         e = InputEvent(ev.sec, ev.usec, ev.type, ev.code, ev.value)
@@ -896,7 +902,7 @@ class InputEvent(object):
         """
         return Libevdev.event_to_name(self.type, self.code)
 
-class _UinputDevice(ctypes.Structure):
+class _UinputDevice(_ctypes.Structure):
     pass
 
 class UinputDevice(_LibraryWrapper):
@@ -906,33 +912,33 @@ class UinputDevice(_LibraryWrapper):
 
     @staticmethod
     def _cdll():
-        return ctypes.CDLL("libevdev.so.2", use_errno=True)
+        return _ctypes.CDLL("libevdev.so.2", use_errno=True)
 
     _api_prototypes = {
         # int libevdev_uinput_create_from_device(const struct libevdev *, int, struct libevdev_uinput **)
         "libevdev_uinput_create_from_device" : {
-            "argtypes": (c_void_p, c_int, ctypes.POINTER(ctypes.POINTER(_UinputDevice))),
-            "restype" : c_int
+            "argtypes": (_c_void_p, _c_int, _ctypes.POINTER(_ctypes.POINTER(_UinputDevice))),
+            "restype" : _c_int
         },
         # int libevdev_uinput_destroy(const struct libevdev *)
         "libevdev_uinput_destroy" : {
-            "argtypes": (c_void_p,),
+            "argtypes": (_c_void_p,),
             "restype" : None,
         },
         # const char* libevdev_uinput_get_devnode(const struct libevdev *)
         "libevdev_uinput_get_devnode" : {
-            "argtypes": (c_void_p,),
-            "restype": c_char_p,
+            "argtypes": (_c_void_p,),
+            "restype": _c_char_p,
         },
         # const char* libevdev_uinput_get_syspath(const struct libevdev *)
         "libevdev_uinput_get_syspath" : {
-            "argtypes": (c_void_p,),
-            "restype": c_char_p,
+            "argtypes": (_c_void_p,),
+            "restype": _c_char_p,
         },
         # int libevdev_uinput_write_event(const struct libevdev *, uint, uint, int)
         "libevdev_uinput_write_event" : {
-            "argtypes": (c_void_p, c_uint, c_uint, c_int),
-            "restype" : c_int
+            "argtypes": (_c_void_p, _c_uint, _c_uint, _c_int),
+            "restype" : _c_int
         },
     }
 
@@ -954,10 +960,10 @@ class UinputDevice(_LibraryWrapper):
         else:
             fd = fileobj.fileno()
 
-        self._uinput_device = ctypes.POINTER(_UinputDevice)()
-        rc = self._uinput_create_from_device(source._ctx, fd, ctypes.byref(self._uinput_device))
+        self._uinput_device = _ctypes.POINTER(_UinputDevice)()
+        rc = self._uinput_create_from_device(source._ctx, fd, _ctypes.byref(self._uinput_device))
         if rc != 0:
-            raise OSError(-rc, os.strerror(-rc))
+            raise OSError(-rc, _os.strerror(-rc))
 
     def __del__(self):
         if self._uinput_device is not None:

--- a/libevdev/__init__.py
+++ b/libevdev/__init__.py
@@ -36,6 +36,7 @@ READ_FLAG_NORMAL = 0x2
 READ_FLAG_FORCE_SYNC = 0x4
 READ_FLAG_BLOCKING = 0x8
 
+
 class _InputAbsinfo(_ctypes.Structure):
     _fields_ = [("value", _c_int32),
                 ("minimum", _c_int32),
@@ -44,6 +45,7 @@ class _InputAbsinfo(_ctypes.Structure):
                 ("flat", _c_int32),
                 ("resolution", _c_int32)]
 
+
 class _InputEvent(_ctypes.Structure):
     _fields_ = [("sec", _c_long),
                 ("usec", _c_long),
@@ -51,19 +53,20 @@ class _InputEvent(_ctypes.Structure):
                 ("code", _c_uint16),
                 ("value", _c_int32)]
 
+
 class _LibraryWrapper(object):
     """
     Base class for wrapping a shared library. Do not use directly.
     """
-    _lib = None # The shared library, shared between instances of the class
+    _lib = None  # The shared library, shared between instances of the class
 
     # List of API prototypes, must be set by the subclass
     _api_prototypes = {
-            # "function_name" : {
-            #   "argtypes": [c_void_p, c_char_p, etc. ], # arguments
-            #   "restype": c_void_p, # return type
-            #   "restype": c_void_p, # return type
-            # }
+        # "function_name" : {
+        #   "argtypes": [c_void_p, c_char_p, etc. ], # arguments
+        #   "restype": c_void_p, # return type
+        #   "restype": c_void_p, # return type
+        # }
     }
 
     def __init__(self):
@@ -95,6 +98,7 @@ class _LibraryWrapper(object):
         """Override in subclass"""
         raise NotImplementedError
 
+
 class Libevdev(_LibraryWrapper):
     """
     This class provides a wrapper around the libevdev C library.
@@ -113,237 +117,237 @@ class Libevdev(_LibraryWrapper):
         return _ctypes.CDLL("libevdev.so.2", use_errno=True)
 
     _api_prototypes = {
-        #const char *libevdev_event_type_get_name(unsigned int type);
+        # const char *libevdev_event_type_get_name(unsigned int type);
         "libevdev_event_type_get_name": {
             "argtypes": (_c_uint,),
             "restype": _c_char_p
-            },
-        #int libevdev_event_type_from_name(const char *name);
+        },
+        # int libevdev_event_type_from_name(const char *name);
         "libevdev_event_type_from_name": {
             "argtypes": (_c_char_p,),
             "restype": _c_int
-            },
-        #const char *libevdev_event_code_get_name(unsigned int type, unsigned int code);
+        },
+        # const char *libevdev_event_code_get_name(unsigned int type, unsigned int code);
         "libevdev_event_code_get_name": {
             "argtypes": (_c_uint, _c_uint,),
             "restype": _c_char_p
-            },
-        #int libevdev_event_code_from_name(unsigned int type, const char *name);
+        },
+        # int libevdev_event_code_from_name(unsigned int type, const char *name);
         "libevdev_event_code_from_name": {
             "argtypes": (_c_uint, _c_char_p,),
             "restype": _c_int
-            },
-        #const char *libevdev_property_get_name(unsigned int prop);
+        },
+        # const char *libevdev_property_get_name(unsigned int prop);
         "libevdev_property_get_name": {
             "argtypes": (_c_uint,),
             "restype": _c_char_p,
-            },
-        #int libevdev_property_from_name(const char *name);
+        },
+        # int libevdev_property_from_name(const char *name);
         "libevdev_property_from_name": {
             "argtypes": (_c_char_p,),
             "restype": _c_int
-            },
-        #void libevdev_event_type_get_max(int)
+        },
+        # void libevdev_event_type_get_max(int)
         "libevdev_event_type_get_max": {
             "argtypes": (_c_int, ),
             "restype": _c_int,
-            },
-        #struct libevdev *libevdev_new(void);
+        },
+        # struct libevdev *libevdev_new(void);
         "libevdev_new": {
             "argtypes": (),
             "restype": _c_void_p,
-            },
-        #struct libevdev *libevdev_free(struct libevdev *);
+        },
+        # struct libevdev *libevdev_free(struct libevdev *);
         "libevdev_free": {
             "argtypes": (_c_void_p,),
             "restype": None,
-            },
+        },
         ###############################
         # Simple getters and setters  #
         ###############################
-        #const char * libevdev_get_name(struct libevdev *);
+        # const char * libevdev_get_name(struct libevdev *);
         "libevdev_get_name": {
             "argtypes": (_c_void_p,),
             "restype": _c_char_p,
-            },
-        #void libevdev_set_name(struct libevdev *, const char*);
+        },
+        # void libevdev_set_name(struct libevdev *, const char*);
         "libevdev_set_name": {
             "argtypes": (_c_void_p, _c_char_p),
             "restype": None,
-            },
-        #const char * libevdev_get_phys(struct libevdev *);
+        },
+        # const char * libevdev_get_phys(struct libevdev *);
         "libevdev_get_phys": {
             "argtypes": (_c_void_p,),
             "restype": _c_char_p,
-            },
-        #void libevdev_set_phys(struct libevdev *, const char*);
+        },
+        # void libevdev_set_phys(struct libevdev *, const char*);
         "libevdev_set_phys": {
             "argtypes": (_c_void_p, _c_char_p),
             "restype": None,
-            },
-        #const char * libevdev_get_uniq(struct libevdev *);
+        },
+        # const char * libevdev_get_uniq(struct libevdev *);
         "libevdev_get_uniq": {
             "argtypes": (_c_void_p,),
             "restype": _c_char_p,
-            },
-        #void libevdev_set_uniq(struct libevdev *, const char*);
+        },
+        # void libevdev_set_uniq(struct libevdev *, const char*);
         "libevdev_set_uniq": {
             "argtypes": (_c_void_p, _c_char_p),
             "restype": None,
-            },
-        #int libevdev_get_driver_version(struct libevdev *);
+        },
+        # int libevdev_get_driver_version(struct libevdev *);
         "libevdev_get_driver_version": {
             "argtypes": (_c_void_p, ),
             "restype": _c_int,
-            },
-        #void libevdev_set_clock_id(struct libevdev *, int)
+        },
+        # void libevdev_set_clock_id(struct libevdev *, int)
         "libevdev_set_clock_id": {
             "argtypes": (_c_void_p, _c_int),
             "restype": _c_int,
-            },
+        },
         ###############################
         # Custom getters and setters  #
         ###############################
-        #int libevdev_get_id_bustype(struct libevdev *)
+        # int libevdev_get_id_bustype(struct libevdev *)
         "libevdev_get_id_bustype": {
             "argtypes": (_c_void_p,),
             "restype": _c_int,
-            },
-        #int libevdev_get_id_vendor(struct libevdev *)
+        },
+        # int libevdev_get_id_vendor(struct libevdev *)
         "libevdev_get_id_vendor": {
             "argtypes": (_c_void_p,),
             "restype": _c_int,
-            },
-        #int libevdev_get_id_product(struct libevdev *)
+        },
+        # int libevdev_get_id_product(struct libevdev *)
         "libevdev_get_id_product": {
             "argtypes": (_c_void_p,),
             "restype": _c_int,
-            },
-        #int libevdev_get_id_version(struct libevdev *)
+        },
+        # int libevdev_get_id_version(struct libevdev *)
         "libevdev_get_id_version": {
             "argtypes": (_c_void_p,),
             "restype": _c_int,
-            },
-        #void libevdev_set_id_bustype(struct libevdev *, int)
+        },
+        # void libevdev_set_id_bustype(struct libevdev *, int)
         "libevdev_set_id_bustype": {
             "argtypes": (_c_void_p, _c_int),
             "restype": None,
-            },
-        #void libevdev_set_id_vendor(struct libevdev *, int)
+        },
+        # void libevdev_set_id_vendor(struct libevdev *, int)
         "libevdev_set_id_vendor": {
             "argtypes": (_c_void_p, _c_int),
             "restype": None,
-            },
-        #void libevdev_set_id_product(struct libevdev *, int)
+        },
+        # void libevdev_set_id_product(struct libevdev *, int)
         "libevdev_set_id_product": {
             "argtypes": (_c_void_p, _c_int),
             "restype": None,
-            },
-        #void libevdev_set_id_version(struct libevdev *, int)
+        },
+        # void libevdev_set_id_version(struct libevdev *, int)
         "libevdev_set_id_version": {
             "argtypes": (_c_void_p, _c_int),
             "restype": None,
-            },
+        },
         # int libevdev_set_fd(struct libevdev *, int)
-        "libevdev_set_fd" : {
-            "argtypes" : (_c_void_p, _c_int),
-            "restype" : _c_int,
+        "libevdev_set_fd": {
+            "argtypes": (_c_void_p, _c_int),
+            "restype": _c_int,
         },
         # int libevdev_change_fd(struct libevdev *, int)
-        "libevdev_change_fd" : {
-            "argtypes" : (_c_void_p, _c_int),
-            "restype" : _c_int,
+        "libevdev_change_fd": {
+            "argtypes": (_c_void_p, _c_int),
+            "restype": _c_int,
         },
         # int libevdev_get_fd(struct libevdev *)
-        "libevdev_get_fd" : {
-            "argtypes" : (_c_void_p, ),
-            "restype" : _c_int,
+        "libevdev_get_fd": {
+            "argtypes": (_c_void_p, ),
+            "restype": _c_int,
         },
         # int libevdev_grab(struct libevdev *)
         "libevdev_grab": {
-            "argtypes" : (_c_void_p, _c_int),
-            "restype" : _c_int,
+            "argtypes": (_c_void_p, _c_int),
+            "restype": _c_int,
         },
         # const struct input_absinfo *libevdev_get_abs_info(struct libevdev*,  int code)
-        "libevdev_get_abs_info" : {
-            "argtypes" : (_c_void_p, _c_int),
-            "restype" : _ctypes.POINTER(_InputAbsinfo),
+        "libevdev_get_abs_info": {
+            "argtypes": (_c_void_p, _c_int),
+            "restype": _ctypes.POINTER(_InputAbsinfo),
         },
         # We don't need to wrap libevdev_set_abs_info(), we get the same
         # using get_abs_info and overwrite the values.
         #
         # const struct input_absinfo *libevdev_get_abs_info(struct libevdev*,  int code)
-        "libevdev_kernel_set_abs_info" : {
-            "argtypes" : (_c_void_p, _ctypes.POINTER(_InputAbsinfo)),
-            "restype" : (_c_int)
+        "libevdev_kernel_set_abs_info": {
+            "argtypes": (_c_void_p, _ctypes.POINTER(_InputAbsinfo)),
+            "restype": (_c_int)
         },
         ##########################
         # Various has_ functions #
         ##########################
-        "libevdev_has_property" : {
-            "argtypes" : (_c_void_p, _c_int),
-            "restype" : (_c_int)
+        "libevdev_has_property": {
+            "argtypes": (_c_void_p, _c_int),
+            "restype": (_c_int)
         },
-        "libevdev_has_event_type" : {
-            "argtypes" : (_c_void_p, _c_int),
-            "restype" : (_c_int)
+        "libevdev_has_event_type": {
+            "argtypes": (_c_void_p, _c_int),
+            "restype": (_c_int)
         },
-        "libevdev_has_event_code" : {
-            "argtypes" : (_c_void_p, _c_int, _c_int),
-            "restype" : (_c_int)
+        "libevdev_has_event_code": {
+            "argtypes": (_c_void_p, _c_int, _c_int),
+            "restype": (_c_int)
         },
         ##########################
         # Other functions        #
         ##########################
-        "libevdev_set_event_value" : {
-            "argtypes" : (_c_void_p, _c_int, _c_int, _c_int),
-            "restype" : (_c_int)
+        "libevdev_set_event_value": {
+            "argtypes": (_c_void_p, _c_int, _c_int, _c_int),
+            "restype": (_c_int)
         },
-        "libevdev_get_event_value" : {
-            "argtypes" : (_c_void_p, _c_int, _c_int),
-            "restype" : (_c_int),
+        "libevdev_get_event_value": {
+            "argtypes": (_c_void_p, _c_int, _c_int),
+            "restype": (_c_int),
         },
-        "libevdev_enable_event_type" : {
-            "argtypes" : (_c_void_p, _c_int),
-            "restype" : (_c_int),
+        "libevdev_enable_event_type": {
+            "argtypes": (_c_void_p, _c_int),
+            "restype": (_c_int),
         },
-        "libevdev_enable_event_code" : {
-            "argtypes" : (_c_void_p, _c_int, _c_int, _c_void_p),
-            "restype" : (_c_int),
+        "libevdev_enable_event_code": {
+            "argtypes": (_c_void_p, _c_int, _c_int, _c_void_p),
+            "restype": (_c_int),
         },
-        "libevdev_disable_event_type" : {
-            "argtypes" : (_c_void_p, _c_int),
-            "restype" : (_c_int),
+        "libevdev_disable_event_type": {
+            "argtypes": (_c_void_p, _c_int),
+            "restype": (_c_int),
         },
-        "libevdev_disable_event_code" : {
-            "argtypes" : (_c_void_p, _c_int, _c_int),
-            "restype" : (_c_int),
+        "libevdev_disable_event_code": {
+            "argtypes": (_c_void_p, _c_int, _c_int),
+            "restype": (_c_int),
         },
-        "libevdev_next_event" : {
-            "argtypes" : (_c_void_p, _c_uint, _ctypes.POINTER(_InputEvent)),
-            "restype" : _c_int,
+        "libevdev_next_event": {
+            "argtypes": (_c_void_p, _c_uint, _ctypes.POINTER(_InputEvent)),
+            "restype": _c_int,
         },
-        "libevdev_get_num_slots" : {
-            "argtypes" : (_c_void_p,),
-            "restype" : _c_int,
+        "libevdev_get_num_slots": {
+            "argtypes": (_c_void_p,),
+            "restype": _c_int,
         },
-        "libevdev_get_current_slot" : {
-            "argtypes" : (_c_void_p,),
-            "restype" : _c_int,
+        "libevdev_get_current_slot": {
+            "argtypes": (_c_void_p,),
+            "restype": _c_int,
         },
-        "libevdev_get_slot_value" : {
-            "argtypes" : (_c_void_p, _c_uint, _c_uint),
-            "restype" : _c_int,
+        "libevdev_get_slot_value": {
+            "argtypes": (_c_void_p, _c_uint, _c_uint),
+            "restype": _c_int,
         },
-        "libevdev_set_slot_value" : {
-            "argtypes" : (_c_void_p, _c_uint, _c_uint, _c_int),
-            "restype" : _c_int,
+        "libevdev_set_slot_value": {
+            "argtypes": (_c_void_p, _c_uint, _c_uint, _c_int),
+            "restype": _c_int,
         },
-        "libevdev_has_event_pending" : {
-            "argtypes" : (_c_void_p,),
-            "restype" : _c_int,
+        "libevdev_has_event_pending": {
+            "argtypes": (_c_void_p,),
+            "restype": _c_int,
         },
-        }
+    }
 
     def __init__(self, fd=None):
         """
@@ -449,10 +453,11 @@ class Libevdev(_LibraryWrapper):
         vdr = self._get_id_vendor(self._ctx)
         pro = self._get_id_product(self._ctx)
         ver = self._get_id_version(self._ctx)
-        return { "bustype" : bus,
-                 "vendor" : vdr,
-                 "product" : pro,
-                 "version" : ver }
+        return {"bustype": bus,
+                "vendor": vdr,
+                "product": pro,
+                "version": ver}
+
     @id.setter
     def id(self, vals):
         if "bustype" in vals:
@@ -571,12 +576,12 @@ class Libevdev(_LibraryWrapper):
             if kernel:
                 self._kernel_set_abs_info(self._ctx, absinfo)
 
-        return { "value" : absinfo.contents.value,
-                 "minimum" : absinfo.contents.minimum,
-                 "maximum" : absinfo.contents.maximum,
-                 "fuzz" : absinfo.contents.fuzz,
-                 "flat" : absinfo.contents.flat,
-                 "resolution" : absinfo.contents.resolution }
+        return {"value": absinfo.contents.value,
+                "minimum": absinfo.contents.minimum,
+                "maximum": absinfo.contents.maximum,
+                "fuzz": absinfo.contents.fuzz,
+                "flat": absinfo.contents.flat,
+                "resolution": absinfo.contents.resolution}
 
     @classmethod
     def property_to_name(cls, prop):
@@ -613,7 +618,7 @@ class Libevdev(_LibraryWrapper):
         """
         if not isinstance(type, int):
             type = cls.event_to_value(type)
-        m =  cls._event_type_get_max(type)
+        m = cls._event_type_get_max(type)
         return m if m > -1 else None
 
     @classmethod
@@ -666,7 +671,7 @@ class Libevdev(_LibraryWrapper):
         r = self._has_property(self._ctx, prop)
         return bool(r)
 
-    def has_event(self, event_type,  event_code=None):
+    def has_event(self, event_type, event_code=None):
         """
         :param event_type: the event type, either as integer or as string
         :param event_code: optional, the event code, either as integer or as
@@ -775,15 +780,15 @@ class Libevdev(_LibraryWrapper):
         if c is None:
             self._enable_event_type(self._ctx, t)
         else:
-            if t == 0x03: # EV_ABS
-                data = _InputAbsinfo(data.get("value", 0), \
-                                     data.get("minimum", 0), \
-                                     data.get("maximum", 0), \
+            if t == 0x03:  # EV_ABS
+                data = _InputAbsinfo(data.get("value", 0),
+                                     data.get("minimum", 0),
+                                     data.get("maximum", 0),
                                      data.get("fuzz", 0),
-                                     data.get("flat", 0), \
+                                     data.get("flat", 0),
                                      data.get("resolution", 0))
                 data = _ctypes.pointer(data)
-            elif t == 0x14: #EV_REP
+            elif t == 0x14:  # EV_REP
                 data = _ctypes.pointer(data)
             self._enable_event_code(self._ctx, t, c, data)
 
@@ -834,21 +839,23 @@ class Libevdev(_LibraryWrapper):
             return None
 
         e = InputEvent(ev.sec, ev.usec, ev.type, ev.code, ev.value)
-        if rc == 1: # READ_STATUS_SYNC
+        if rc == 1:  # READ_STATUS_SYNC
             assert(e.matches("EV_SYN", "SYN_DROPPED"))
         return e
+
 
 class InputEvent(object):
     """
     Represents one input event of type struct input_event as defined in
     linux/input.h and returned by libevdev_next_event().
     """
+
     def __init__(self, sec, usec, type, code, value):
         self.sec = sec
         self.usec = usec
         self.type = type
         self.code = code
-        self.value = value;
+        self.value = value
 
     def matches(self, type, code=None):
         """
@@ -902,8 +909,10 @@ class InputEvent(object):
         """
         return Libevdev.event_to_name(self.type, self.code)
 
+
 class _UinputDevice(_ctypes.Structure):
     pass
+
 
 class UinputDevice(_LibraryWrapper):
     """
@@ -916,29 +925,29 @@ class UinputDevice(_LibraryWrapper):
 
     _api_prototypes = {
         # int libevdev_uinput_create_from_device(const struct libevdev *, int, struct libevdev_uinput **)
-        "libevdev_uinput_create_from_device" : {
+        "libevdev_uinput_create_from_device": {
             "argtypes": (_c_void_p, _c_int, _ctypes.POINTER(_ctypes.POINTER(_UinputDevice))),
-            "restype" : _c_int
+            "restype": _c_int
         },
         # int libevdev_uinput_destroy(const struct libevdev *)
-        "libevdev_uinput_destroy" : {
+        "libevdev_uinput_destroy": {
             "argtypes": (_c_void_p,),
-            "restype" : None,
+            "restype": None,
         },
         # const char* libevdev_uinput_get_devnode(const struct libevdev *)
-        "libevdev_uinput_get_devnode" : {
+        "libevdev_uinput_get_devnode": {
             "argtypes": (_c_void_p,),
             "restype": _c_char_p,
         },
         # const char* libevdev_uinput_get_syspath(const struct libevdev *)
-        "libevdev_uinput_get_syspath" : {
+        "libevdev_uinput_get_syspath": {
             "argtypes": (_c_void_p,),
             "restype": _c_char_p,
         },
         # int libevdev_uinput_write_event(const struct libevdev *, uint, uint, int)
-        "libevdev_uinput_write_event" : {
+        "libevdev_uinput_write_event": {
             "argtypes": (_c_void_p, _c_uint, _c_uint, _c_int),
-            "restype" : _c_int
+            "restype": _c_int
         },
     }
 
@@ -956,7 +965,7 @@ class UinputDevice(_LibraryWrapper):
 
         self._fileobj = fileobj
         if fileobj is None:
-            fd = -2 # UINPUT_OPEN_MANAGED
+            fd = -2  # UINPUT_OPEN_MANAGED
         else:
             fd = fileobj.fileno()
 

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,10 @@
 from distutils.core import setup
 
 setup(name='libevdev',
-        version='0.1',
-        description='Python wrapper for libevdev',
-        author='Peter Hutterer',
-        author_email='peter.hutterer@who-t.net',
-        url='https://www.github.com/whot/libevdev-python/',
-        packages=['libevdev'],
-        )
-
+      version='0.1',
+      description='Python wrapper for libevdev',
+      author='Peter Hutterer',
+      author_email='peter.hutterer@who-t.net',
+      url='https://www.github.com/whot/libevdev-python/',
+      packages=['libevdev'],
+      )

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -7,7 +7,9 @@ from libevdev import *
 # if properties 1-4 work the others will work too if libevdev works
 # correctly
 
+
 class TestNameConversion(unittest.TestCase):
+
     def test_type_max(self):
         for t in ["REL", "ABS"]:
             c = Libevdev.event_to_value("EV_{}".format(t), "{}_MAX".format(t))
@@ -92,6 +94,7 @@ class TestNameConversion(unittest.TestCase):
 
 
 class TestLibevdevDevice(unittest.TestCase):
+
     def test_ctx_init(self):
         l = Libevdev()
         del l
@@ -179,11 +182,13 @@ class TestLibevdevDevice(unittest.TestCase):
         self.assertEqual(id["product"], 3)
         self.assertEqual(id["version"], 5)
 
+
 class TestRealDevice(unittest.TestCase):
     """
     Tests various things against /dev/input/event3 which is usually the
     keyboard. Requires root rights though.
     """
+
     def setUp(self):
         self.fd = open("/dev/input/event3", "rb")
 
@@ -260,7 +265,7 @@ class TestRealDevice(unittest.TestCase):
         for i in range(1, 5):
             if l.has_event(i):
                 type_supported = i
-                break;
+                break
 
         self.assertGreater(type_supported, 0)
 
@@ -298,6 +303,7 @@ class TestRealDevice(unittest.TestCase):
         l = Libevdev(self.fd)
         self.assertIsNone(l.num_slots)
 
+
 class TestAbsDevice(unittest.TestCase):
     """
     Tests various things against the first device with EV_ABS.
@@ -305,6 +311,7 @@ class TestAbsDevice(unittest.TestCase):
     that's nonzero and is the most common ABS anyway.
     Requires root rights.
     """
+
     def setUp(self):
         want_fd = None
         for i in range(20):
@@ -403,23 +410,25 @@ class TestAbsDevice(unittest.TestCase):
         l.disable("EV_REL", "REL_RY")
         self.assertFalse(l.has_event("EV_REL", "REL_RY"))
 
-        data = { "minimum" : 100,
-                 "maximum" : 200,
-                 "value" : 300,
-                 "fuzz" : 400,
-                 "flat" : 500,
-                 "resolution" : 600 }
+        data = {"minimum": 100,
+                "maximum": 200,
+                "value": 300,
+                "fuzz": 400,
+                "flat": 500,
+                "resolution": 600}
         self.assertFalse(l.has_event("EV_ABS", "ABS_RY"))
         l.enable("EV_ABS", "ABS_RY", data)
         self.assertTrue(l.has_event("EV_ABS", "ABS_RY"))
         l.disable("EV_ABS", "ABS_RY")
         self.assertFalse(l.has_event("EV_ABS", "ABS_RY"))
 
+
 class TestMTDevice(unittest.TestCase):
     """
     Tests various things against the first MT device found.
     Requires root rights.
     """
+
     def setUp(self):
         want_fd = None
         for i in range(20):
@@ -470,6 +479,7 @@ class TestUinput(unittest.TestCase):
     Tests uinput device creation.
     Requires root rights.
     """
+
     def is_identical(self, d1, d2):
         for t in range(Libevdev.event_to_value("EV_MAX")):
             max = Libevdev.type_max(t)
@@ -505,8 +515,8 @@ class TestUinput(unittest.TestCase):
             self.assertTrue(self.is_identical(dev, newdev))
 
     def testAbsolute(self):
-        absinfo = { "minimum" : 0,
-                    "maximum" : 1 }
+        absinfo = {"minimum": 0,
+                   "maximum": 1}
 
         dev = Libevdev()
         dev.name = "test device"

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -545,5 +545,6 @@ class TestUinput(unittest.TestCase):
         uinput = UinputDevice(dev)
         self.assertTrue(uinput.syspath.startswith("/sys/devices/virtual/input/input"))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,6 @@
 import unittest
 import ctypes
-from libevdev import *
+from libevdev import Libevdev, UinputDevice
 
 # Note: these tests test for the correct functioning of the python bindings,
 # not of libevdev underneath. Some ranges are hardcoded for simplicity, e.g.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -46,7 +46,7 @@ class TestNameConversion(unittest.TestCase):
             self.assertIsNotNone(name)
             self.assertTrue(name.startswith("EV_"))
             self.assertNotEqual(prevname, name)
-            prename = name
+            prevname = name
 
     def test_type_to_name_invalid(self):
         name = Libevdev.event_to_name(-1)
@@ -379,7 +379,7 @@ class TestAbsDevice(unittest.TestCase):
     def test_set_absinfo_invalid(self):
         l = Libevdev(self.fd)
         with self.assertRaises(ValueError):
-            a = l.absinfo("REL_X")
+            l.absinfo("REL_X")
 
     def test_set_absinfo_kernel(self):
         # FIXME: yeah, nah, not testing that on a random device...

--- a/test/test-events.py
+++ b/test/test-events.py
@@ -2,6 +2,7 @@ import sys
 
 from libevdev import *
 
+
 def main(argv):
     device = argv[1]
     with open(device, "rb") as fd:
@@ -17,6 +18,3 @@ if __name__ == '__main__':
         print("Usage: {} /dev/input/eventX".format(sys.argv[0]))
         sys.exit(1)
     main(sys.argv)
-    
-
-

--- a/test/test-events.py
+++ b/test/test-events.py
@@ -13,6 +13,7 @@ def main(argv):
             if ev.matches("EV_SYN", "SYN_REPORT"):
                 break
 
+
 if __name__ == '__main__':
     if len(sys.argv) <= 1:
         print("Usage: {} /dev/input/eventX".format(sys.argv[0]))

--- a/test/test-events.py
+++ b/test/test-events.py
@@ -1,6 +1,6 @@
 import sys
 
-from libevdev import *
+from libevdev import Libevdev
 
 
 def main(argv):


### PR DESCRIPTION
Small cleanups for libevdev-python to not export dependencies (os, ctypes, etc...) and fix most of the PEP8 warnings reported by flake8.